### PR TITLE
💄 CommentHeader 컴포넌트 분리 및 스타일 수정

### DIFF
--- a/src/components/Common/EditDeleteButton/EditDeleteButton.jsx
+++ b/src/components/Common/EditDeleteButton/EditDeleteButton.jsx
@@ -14,7 +14,7 @@ export const EditDeleteButton = ({ handleEdit, handleDelete }) => {
   };
 
   return (
-    <S.ButtonContainer onClick={handleClick}>
+    <S.ButtonContainer onClick={handleClick} className="btnWrap">
       <Icon Icon={Dots} size={20} />
       {toggle && (
         <S.Button>

--- a/src/components/Common/LabelTag/LabelTag.jsx
+++ b/src/components/Common/LabelTag/LabelTag.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const CategoryTag = ({ name }) => {
+export const LabelTag = ({ name }) => {
   return <Tag>{name}</Tag>;
 };
 

--- a/src/components/Common/UserHeader/UserHeader.jsx
+++ b/src/components/Common/UserHeader/UserHeader.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { CategoryTag, ProfileImage } from 'components/Common';
+import { LabelTag, ProfileImage } from 'components/Common';
 import { getAge } from 'utils/dateConverter';
 import * as S from './styles';
 
-export const UserHeader = ({ data }) => {
+export const UserHeader = ({ postData }) => {
   const {
     author: { birth, nickname, profile_image_url, location }
-  } = data;
+  } = postData;
 
   const { pathname } = useLocation();
   const isMain = pathname === '/';
 
-  const tag = isMain && data.category.category_name;
+  const tag = isMain && postData.category.category_name;
 
   const town = location && location.split(' ')[2];
 
@@ -24,7 +24,7 @@ export const UserHeader = ({ data }) => {
         <span className="age">{getAge(birth)}</span>
         {!isMain && <span className="town">{town || '상도동'}</span>}
       </S.UserInfo>
-      {tag && isMain && <CategoryTag name={tag} />}
+      {isMain && <LabelTag name={tag} />}
     </S.HeaderContainer>
   );
 };

--- a/src/components/Common/index.js
+++ b/src/components/Common/index.js
@@ -5,7 +5,7 @@ export { Category } from './Category/Category';
 export { ScrollContainer } from './ScrollContainer/ScrollContainer';
 export { ScrollHorizon } from './ScrollHorizon/ScrollHorizon';
 export { ProfileImage } from './ProfileImage/ProfileImage';
-export { CategoryTag } from './CategoryTag/CategoryTag';
+export { LabelTag } from './LabelTag/LabelTag';
 export { TextClamp } from './TextClamp/TextClamp';
 export { MenuTab } from './MenuTab/MenuTab';
 export { FetchObserver } from './FetchObserver/FetchObserver';

--- a/src/components/FeedView/Comments/CommentContents/CommentContents.jsx
+++ b/src/components/FeedView/Comments/CommentContents/CommentContents.jsx
@@ -3,10 +3,10 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { toast } from 'react-toastify';
 import { user } from 'api/queries/user';
 import { comments } from 'api/queries/comment';
-import { EditDeleteButton, Icon, UserHeader } from 'components/Common';
-import { EditForm } from '../EditForm/EditForm';
+import { EditDeleteButton, Icon } from 'components/Common';
 import { ReactComponent as Comment } from 'assets/icons/comment.svg';
 import { dateFormat } from 'utils/dateConverter';
+import * as C from 'components/FeedView';
 import * as S from './styles';
 
 export const CommentContents = ({
@@ -46,19 +46,19 @@ export const CommentContents = ({
 
   return (
     <>
-      <S.CommentHeader>
-        <UserHeader data={contents} feedAuthor={feedAuthor} />
+      <S.HeaderWrap>
+        <C.CommentHeader data={contents} feedAuthor={feedAuthor} />
         {!isLoading && data.user_id === author.user_id && (
           <EditDeleteButton
             handleDelete={() => deleteCommentMutate(comment_id)}
             handleEdit={() => setIsEditing(prev => !prev)}
           />
         )}
-      </S.CommentHeader>
+      </S.HeaderWrap>
 
       <S.CommentText>
         {isEditing ? (
-          <EditForm
+          <C.EditForm
             content={content}
             commentId={comment_id}
             setIsEditing={setIsEditing}

--- a/src/components/FeedView/Comments/CommentContents/CommentContents.jsx
+++ b/src/components/FeedView/Comments/CommentContents/CommentContents.jsx
@@ -29,6 +29,7 @@ export const CommentContents = ({
     onSuccess: () => {
       toast.success('댓글이 성공적으로 삭제되었습니다.');
       queryClient.invalidateQueries('comments');
+      queryClient.invalidateQueries('feed-detail');
     },
     onError: error => {
       console.log(error.message);

--- a/src/components/FeedView/Comments/CommentContents/CommentContents.jsx
+++ b/src/components/FeedView/Comments/CommentContents/CommentContents.jsx
@@ -47,13 +47,14 @@ export const CommentContents = ({
   return (
     <>
       <S.HeaderWrap>
-        <C.CommentHeader data={contents} feedAuthor={feedAuthor} />
+        <C.CommentHeader contents={contents} feedAuthor={feedAuthor} />
         {!isLoading && data.user_id === author.user_id && (
           <EditDeleteButton
             handleDelete={() => deleteCommentMutate(comment_id)}
             handleEdit={() => setIsEditing(prev => !prev)}
           />
         )}
+        <S.DateWrap>{dateFormat(created_at)}</S.DateWrap>
       </S.HeaderWrap>
 
       <S.CommentText>
@@ -68,7 +69,7 @@ export const CommentContents = ({
         )}
       </S.CommentText>
 
-      <S.CommentFooter className={reply ? 'onlyDate' : ''}>
+      <S.CommentFooter>
         {!reply && (
           <button>
             <Icon Icon={Comment} size={17} />
@@ -77,8 +78,6 @@ export const CommentContents = ({
             </span>
           </button>
         )}
-
-        <div>{dateFormat(created_at)}</div>
       </S.CommentFooter>
     </>
   );

--- a/src/components/FeedView/Comments/CommentContents/styles.js
+++ b/src/components/FeedView/Comments/CommentContents/styles.js
@@ -4,22 +4,26 @@ export const HeaderWrap = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom: 9px;
+  padding-bottom: 15px;
   position: relative;
-  .icon {
-    margin-right: 5px;
-  }
-  .name {
-    font-size: 14px;
-    padding: 0 5px 0 8px;
+  .btnWrap {
+    right: 5px;
+    top: 22px;
   }
   span {
     letter-spacing: -0.5px;
   }
 `;
 
+export const DateWrap = styled.div`
+  font-size: 11px;
+  color: ${({ theme }) => theme.color.black_2};
+  line-height: 28px;
+  margin-bottom: auto;
+`;
+
 export const CommentText = styled.div`
-  padding: 0 10px 6px;
+  padding: 0 10px 15px;
   font-size: 15px;
 `;
 
@@ -29,13 +33,7 @@ export const TextBox = styled.p`
 `;
 
 export const CommentFooter = styled.div`
-  display: flex;
-  justify-content: space-between;
-  padding: 2px 10px 15px 12px;
-  &.onlyDate {
-    justify-content: flex-end;
-    padding-bottom: 10px;
-  }
+  padding: 0px 12px 10px;
   button {
     display: flex;
     align-items: center;
@@ -48,10 +46,5 @@ export const CommentFooter = styled.div`
       padding-left: 4.5px;
       color: ${({ theme }) => theme.color.black_2};
     }
-  }
-  div {
-    font-size: 11px;
-    color: ${({ theme }) => theme.color.black_2};
-    line-height: 28px;
   }
 `;

--- a/src/components/FeedView/Comments/CommentContents/styles.js
+++ b/src/components/FeedView/Comments/CommentContents/styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const CommentHeader = styled.div`
+export const HeaderWrap = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/FeedView/Comments/CommentForm/CommentForm.jsx
+++ b/src/components/FeedView/Comments/CommentForm/CommentForm.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
+
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { toast } from 'react-toastify';
 import { user } from 'api/queries/user';
 import { comments } from 'api/queries/comment';
+
+import { toast } from 'react-toastify';
 import { Icon, ProfileImage } from 'components/Common';
 import { ReactComponent as Plane } from 'assets/icons/airplane.svg';
 import * as S from './styles';
@@ -39,6 +41,14 @@ export const CommentForm = ({ feedId }) => {
     }
   };
 
+  const handleEnter = e => {
+    if (e.keyCode === 13) {
+      if (!e.shiftKey) {
+        handleSendComment(e);
+      }
+    }
+  };
+
   return (
     <>
       <S.CommentSendForm>
@@ -50,6 +60,7 @@ export const CommentForm = ({ feedId }) => {
         <S.CommentInput
           value={commentValue}
           onChange={handleChange}
+          onKeyDown={handleEnter}
           placeholder="댓글을 입력해주세요"
         />
         <S.SendBtn onClick={handleSendComment}>

--- a/src/components/FeedView/Comments/CommentForm/CommentForm.jsx
+++ b/src/components/FeedView/Comments/CommentForm/CommentForm.jsx
@@ -21,6 +21,7 @@ export const CommentForm = ({ feedId }) => {
   const { mutate: sendCommentMutate } = useMutation(comments.add, {
     onSuccess: () => {
       queryClient.invalidateQueries('comments');
+      queryClient.invalidateQueries('feed-detail');
     },
     onError: error => {
       console.log(error.message);

--- a/src/components/FeedView/Comments/CommentForm/styles.js
+++ b/src/components/FeedView/Comments/CommentForm/styles.js
@@ -6,11 +6,13 @@ export const CommentSendForm = styled.form`
   align-items: center;
 `;
 
-export const CommentInput = styled.input`
+export const CommentInput = styled.textarea`
+  resize: none;
   margin: 4.5px 6px;
   padding: 4.5px 2px;
   flex: 1;
   width: 50%;
+  height: 40px;
   outline: none;
 `;
 

--- a/src/components/FeedView/Comments/CommentHeader/CommentHeader.jsx
+++ b/src/components/FeedView/Comments/CommentHeader/CommentHeader.jsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 import { CategoryTag, ProfileImage } from 'components/Common';
 import { getAge } from 'utils/dateConverter';
 import * as S from './styles';
 
-export const UserHeader = ({ data }) => {
+export const CommentHeader = ({ data, feedAuthor }) => {
   const {
-    author: { birth, nickname, profile_image_url, location }
+    author: { birth, nickname, profile_image_url, location, user_id }
   } = data;
 
-  const { pathname } = useLocation();
-  const isMain = pathname === '/';
-
-  const tag = isMain && data.category.category_name;
+  const myFeed = feedAuthor === user_id && '글 작성자';
 
   const town = location && location.split(' ')[2];
 
@@ -22,9 +18,9 @@ export const UserHeader = ({ data }) => {
       <S.UserInfo>
         <p className="name">{nickname}</p>
         <span className="age">{getAge(birth)}</span>
-        {!isMain && <span className="town">{town || '상도동'}</span>}
+        <span className="town">{town || '상도동'}</span>
       </S.UserInfo>
-      {tag && isMain && <CategoryTag name={tag} />}
+      {myFeed && <CategoryTag name={myFeed} />}
     </S.HeaderContainer>
   );
 };

--- a/src/components/FeedView/Comments/CommentHeader/CommentHeader.jsx
+++ b/src/components/FeedView/Comments/CommentHeader/CommentHeader.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { CategoryTag, ProfileImage } from 'components/Common';
+import { LabelTag, ProfileImage } from 'components/Common';
 import { getAge } from 'utils/dateConverter';
 import * as S from './styles';
 
-export const CommentHeader = ({ data, feedAuthor }) => {
+export const CommentHeader = ({ contents, feedAuthor }) => {
   const {
     author: { birth, nickname, profile_image_url, location, user_id }
-  } = data;
+  } = contents;
 
   const myFeed = feedAuthor === user_id && '글 작성자';
 
@@ -16,11 +16,15 @@ export const CommentHeader = ({ data, feedAuthor }) => {
     <S.HeaderContainer>
       <ProfileImage size={40} url={profile_image_url} />
       <S.UserInfo>
-        <p className="name">{nickname}</p>
-        <span className="age">{getAge(birth)}</span>
-        <span className="town">{town || '상도동'}</span>
+        <S.InfoBlock>
+          <p className="name">{nickname}</p>
+          {myFeed && <LabelTag name={myFeed} />}
+        </S.InfoBlock>
+        <S.InfoBlock>
+          <span className="age">{getAge(birth)}</span>
+          <span className="town">{town || '상도동'}</span>
+        </S.InfoBlock>
       </S.UserInfo>
-      {myFeed && <CategoryTag name={myFeed} />}
     </S.HeaderContainer>
   );
 };

--- a/src/components/FeedView/Comments/CommentHeader/styles.js
+++ b/src/components/FeedView/Comments/CommentHeader/styles.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+export const HeaderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  span {
+    margin-left: auto;
+  }
+`;
+
+export const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  line-height: 1;
+  .name {
+    font-size: 15.5px;
+    padding: 0 8px 0 11px;
+  }
+  span {
+    font-size: 12px;
+    color: ${({ theme }) => theme.color.black_2};
+  }
+  .town {
+    position: relative;
+    padding-left: 5px;
+    margin: 0 5px;
+  }
+  .town:before {
+    content: '';
+    width: 1px;
+    height: 10px;
+    left: 0;
+    top: 4px;
+    background: #bcbcbc;
+    position: absolute;
+  }
+`;

--- a/src/components/FeedView/Comments/CommentHeader/styles.js
+++ b/src/components/FeedView/Comments/CommentHeader/styles.js
@@ -3,20 +3,15 @@ import styled from 'styled-components';
 export const HeaderContainer = styled.div`
   display: flex;
   align-items: center;
-  span {
-    margin-left: auto;
-  }
 `;
 
 export const UserInfo = styled.div`
-  display: flex;
-  align-items: center;
-  line-height: 1;
   .name {
     font-size: 15.5px;
-    padding: 0 8px 0 11px;
+    padding-right: 6px;
   }
-  span {
+  .age,
+  .town {
     font-size: 12px;
     color: ${({ theme }) => theme.color.black_2};
   }
@@ -34,4 +29,10 @@ export const UserInfo = styled.div`
     background: #bcbcbc;
     position: absolute;
   }
+`;
+
+export const InfoBlock = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 11px;
 `;

--- a/src/components/FeedView/Comments/EditForm/EditForm.jsx
+++ b/src/components/FeedView/Comments/EditForm/EditForm.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+
 import { useMutation, useQueryClient } from 'react-query';
 import { comments } from 'api/queries/comment';
+
 import { toast } from 'react-toastify';
 import * as S from './styles';
 
@@ -35,9 +37,21 @@ export const EditForm = ({ content, commentId, setIsEditing }) => {
     }
   };
 
+  const handleEnter = e => {
+    if (e.keyCode === 13) {
+      if (!e.shiftKey) {
+        handleEditComment(e);
+      }
+    }
+  };
+
   return (
     <S.EditingForm onSubmit={handleEditComment}>
-      <S.EditInput value={editValue} onChange={handleChange} />
+      <S.EditInput
+        value={editValue}
+        onChange={handleChange}
+        onKeyDown={handleEnter}
+      />
       <button onClick={handleEditComment}>완료</button>
     </S.EditingForm>
   );

--- a/src/components/FeedView/Comments/EditForm/EditForm.jsx
+++ b/src/components/FeedView/Comments/EditForm/EditForm.jsx
@@ -27,8 +27,12 @@ export const EditForm = ({ content, commentId, setIsEditing }) => {
 
   const handleEditComment = e => {
     e.preventDefault();
-    editCommentMutate([{ commentId: commentId }, { content: editValue }]);
-    setIsEditing(prev => !prev);
+    if (editValue !== '') {
+      editCommentMutate([{ commentId: commentId }, { content: editValue }]);
+      setIsEditing(prev => !prev);
+    } else {
+      toast.warning('수정할 내용을 입력해주세요.');
+    }
   };
 
   return (

--- a/src/components/FeedView/Comments/EditForm/styles.js
+++ b/src/components/FeedView/Comments/EditForm/styles.js
@@ -12,9 +12,11 @@ export const EditingForm = styled.form`
   }
 `;
 
-export const EditInput = styled.input`
+export const EditInput = styled.textarea`
+  resize: none;
   flex: 1;
   width: 70%;
+  height: 40px;
   padding: 4px 6px;
   border: 1px solid #eaeaea;
   border-radius: 4px;

--- a/src/components/FeedView/Comments/ReplyForm/ReplyForm.jsx
+++ b/src/components/FeedView/Comments/ReplyForm/ReplyForm.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
+
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { toast } from 'react-toastify';
 import { user } from 'api/queries/user';
 import { comments } from 'api/queries/comment';
+
+import { toast } from 'react-toastify';
 import { Icon, ProfileImage } from 'components/Common';
 import { ReactComponent as Plane } from 'assets/icons/airplane.svg';
 import * as S from './styles';
@@ -40,9 +42,17 @@ export const ReplyForm = ({ setIsReplying, replyId }) => {
     }
   };
 
+  const handleEnter = e => {
+    if (e.keyCode === 13) {
+      if (!e.shiftKey) {
+        handleSendReply(e);
+      }
+    }
+  };
+
   return (
     <>
-      <S.CommentSendForm>
+      <S.CommentSendForm onSubmit={handleSendReply}>
         <ProfileImage
           size={40}
           url={!isLoading ? data.profile_image_url : null}
@@ -51,9 +61,10 @@ export const ReplyForm = ({ setIsReplying, replyId }) => {
         <S.CommentInput
           value={replyValue}
           onChange={handleReplyChange}
+          onKeyDown={handleEnter}
           placeholder="답글을 입력해주세요"
-        />
-        <S.SendBtn onClick={handleSendReply}>
+        ></S.CommentInput>
+        <S.SendBtn>
           <Icon Icon={Plane} size={20} color={'#f4f4f4'} />
         </S.SendBtn>
       </S.CommentSendForm>

--- a/src/components/FeedView/Comments/ReplyForm/ReplyForm.jsx
+++ b/src/components/FeedView/Comments/ReplyForm/ReplyForm.jsx
@@ -21,6 +21,7 @@ export const ReplyForm = ({ setIsReplying, replyId }) => {
   const { mutate: replyMutate } = useMutation(comments.reply, {
     onSuccess: () => {
       queryClient.invalidateQueries('comments');
+      queryClient.invalidateQueries('feed-detail');
     },
     onError: error => {
       console.log(error.message);

--- a/src/components/FeedView/Comments/ReplyForm/styles.js
+++ b/src/components/FeedView/Comments/ReplyForm/styles.js
@@ -6,11 +6,13 @@ export const CommentSendForm = styled.form`
   align-items: center;
 `;
 
-export const CommentInput = styled.input`
+export const CommentInput = styled.textarea`
+  resize: none;
   margin: 4.5px 6px;
   padding: 4.5px 2px;
   flex: 1;
   width: 50%;
+  height: 40px;
   outline: none;
 `;
 

--- a/src/components/FeedView/index.js
+++ b/src/components/FeedView/index.js
@@ -3,3 +3,4 @@ export { CommentBody } from './Comments/CommentBody/CommentBody';
 export { CommentForm } from './Comments/CommentForm/CommentForm';
 export { EditForm } from './Comments/EditForm/EditForm';
 export { ReplyForm } from './Comments/ReplyForm/ReplyForm';
+export { CommentHeader } from './Comments/CommentHeader/CommentHeader';

--- a/src/components/MySubPage/MyComments/MyComments.jsx
+++ b/src/components/MySubPage/MyComments/MyComments.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { ReactComponent as Arrow } from 'assets/icons/arrow_angle.svg';
-import {
-  CategoryTag,
-  Icon,
-  TextClamp,
-  EditDeleteButton
-} from 'components/Common';
+import { LabelTag, Icon, TextClamp, EditDeleteButton } from 'components/Common';
 import data from 'data/myComments';
 import * as S from './styles';
 
@@ -14,7 +9,7 @@ export const MyComments = () => {
     <S.ListContainer>
       {data.mycomments.map(({ category, post, comments }, i) => (
         <S.CommentBox key={i}>
-          <CategoryTag name={category} />
+          <LabelTag name={category} />
           <S.PostTitle>
             [<span>{post}</span>]에서 작성한 댓글
           </S.PostTitle>

--- a/src/components/MySubPage/MyMeets/MyMeets.jsx
+++ b/src/components/MySubPage/MyMeets/MyMeets.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { CategoryTag, TextClamp } from 'components/Common';
+import { LabelTag, TextClamp } from 'components/Common';
 import { getDay, isPast } from 'utils/dateConverter';
 import * as S from './styles';
 
@@ -15,7 +15,7 @@ export const MyMeets = ({ section }) => {
           <span>{getDay(date)}</span>
           <S.MeetTitle>
             <TextClamp width={!isPast(date) ? 265 : 0}>{name}</TextClamp>
-            {!isPast(date) && <CategoryTag name="참여예정" />}
+            {!isPast(date) && <LabelTag name="참여예정" />}
           </S.MeetTitle>
           <Link to="#">자세히 보기</Link>
         </S.MeetItem>

--- a/src/components/Post/PostBody/PostBody.jsx
+++ b/src/components/Post/PostBody/PostBody.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CategoryTag, TextClamp } from 'components/Common';
+import { LabelTag, TextClamp } from 'components/Common';
 import * as S from './styles';
 
 export const PostBody = ({ postData }) => {
@@ -10,7 +10,7 @@ export const PostBody = ({ postData }) => {
 
   return (
     <S.BodyContainer>
-      <CategoryTag name={category_name} />
+      <LabelTag name={category_name} />
       <TextClamp line={3}>{content}</TextClamp>
     </S.BodyContainer>
   );

--- a/src/components/Post/PostBodyUser/PostBodyUser.jsx
+++ b/src/components/Post/PostBodyUser/PostBodyUser.jsx
@@ -10,7 +10,7 @@ export const PostBodyUser = ({ postData }) => {
 
   return (
     <S.BodyContainer>
-      <UserHeader data={postData} />
+      <UserHeader postData={postData} />
       <S.PostText>
         {isMain || pathname.includes('list') ? (
           <TextClamp line={3}>{content}</TextClamp>

--- a/src/components/Post/PostBodyUser/PostBodyUser.jsx
+++ b/src/components/Post/PostBodyUser/PostBodyUser.jsx
@@ -3,14 +3,14 @@ import { useLocation } from 'react-router-dom';
 import { TextClamp, UserHeader } from 'components/Common';
 import * as S from './styles';
 
-export const PostBodyUser = ({ postData, view }) => {
+export const PostBodyUser = ({ postData }) => {
   const { content } = postData;
   const { pathname } = useLocation();
   const isMain = pathname === '/';
 
   return (
     <S.BodyContainer>
-      <UserHeader data={postData} view={view} />
+      <UserHeader data={postData} />
       <S.PostText>
         {isMain || pathname.includes('list') ? (
           <TextClamp line={3}>{content}</TextClamp>

--- a/src/pages/FeedViewPage/FeedViewPage.jsx
+++ b/src/pages/FeedViewPage/FeedViewPage.jsx
@@ -25,7 +25,7 @@ export const FeedViewPage = () => {
 
         <ScrollContainer>
           <S.ContentSection>
-            <PostBodyUser postData={data} view />
+            <PostBodyUser postData={data} />
             <C.ImageSlider imgData={data.image_url} />
             <PostFooterBtn postData={data} refetch={refetch} />
           </S.ContentSection>


### PR DESCRIPTION
### 세부구현 사항들
- [x] CommentHeader 컴포넌트를 분리 & 스타일 변경
- [x] comment_count가 댓글 등록/삭제에 따라 바로 갱신되도록 수정
- [x] comment form들의 input을 textarea로 변경 후 enter와 shift+enter 기능 구분

### 전달 사항 
- CategoryTag가 댓글의 `글 작성자` tag로도 활용됨에 따라 이름을 변경 & 업데이트했습니다.
- EditDeleteButton 컴포넌트의 원활한 위치조정(absolute)을 위해 className을 부여했습니다.
- CommentHeader를 분리함에 따라 feed에 사용되는 Header 컴포넌트의 data라는 props명을 직관적으로 파악할 수 있도록 postData로 변경했습니다.
- 댓글 입력창의 높이를 버튼과 맞추었습니다.

### 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다
